### PR TITLE
fixing problem on class namespace

### DIFF
--- a/src/TranslationExtension.php
+++ b/src/TranslationExtension.php
@@ -35,7 +35,7 @@
  * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-namespace Pmt\Slim\Twig\Extension;
+namespace abedmaatalla\Slim\Twig\Extension;
 
 use Illuminate\Translation\Translator;
 


### PR DESCRIPTION
Hi, Abed. I found a bug in the class namespace.

When class is used on the controller, Slim returns an error like 'Class not found'.
I've changed the namespace to 'abedmaatalla\Slim\Twig\Extension' and the problem was solved.

bye.